### PR TITLE
fix issue with fsspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pie-models
 
-Model and Taskmodule implementations for [PyTorch-IE](https://github.com/ChristophAlt/pytorch-ie) .
+Model and Taskmodule implementations for [PyTorch-IE](https://github.com/ChristophAlt/pytorch-ie).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pie-models
 
-Model and Taskmodule implementations for [PyTorch-IE](https://github.com/ChristophAlt/pytorch-ie).
+Model and Taskmodule implementations for [PyTorch-IE](https://github.com/ChristophAlt/pytorch-ie) .
 
 ## Setup
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
     "pytorch-ie>=0.19.0,<1.0.0",
-    "fsspec<=2021.06.0",  # 2021.09.0 causes a bug with datasets, i.e. test_datasets() fails
+    "fsspec<=2023.06.0",  # 2023.09.0 causes a bug with datasets, i.e. test_datasets() fails
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
     "pytorch-ie>=0.19.0,<1.0.0",
+    "fsspec<=2021.06.0",  # 2021.09.0 causes a bug with datasets, i.e. test_datasets() fails
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
Primarily, this PR pins `fsspec` to `2023.06.0` or below because `2023.09.0` causes issues with `datasets` (the splits of a HF dataset loaded from json contains duplicated instances).