### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@update_datasets_and_transformers",
+    # requires:
+    # - https://github.com/ChristophAlt/pytorch-ie/pull/323
+    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@update_pytorch_lightning",
+    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git",
+    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@update_datasets_and_transformers",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie>=0.19.0,<1.0.0",
-    "fsspec<=2023.06.0",  # 2023.09.0 causes a bug with datasets, i.e. test_datasets() fails
+    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@update_pytorch_lightning",
 ]
 
 TESTS_REQUIRE = [

--- a/src/pie_models/models/sequence_classification.py
+++ b/src/pie_models/models/sequence_classification.py
@@ -17,7 +17,7 @@ ModelInputType: TypeAlias = MutableMapping[str, Any]
 # A dict with a single key "logits".
 ModelOutputType: TypeAlias = Dict[str, Tensor]
 # This contains the input and target tensors for a single training step.
-StepInputType: TypeAlias = Tuple[
+ModelStepInputType: TypeAlias = Tuple[
     ModelInputType,  # input
     Optional[Tensor],  # targets
 ]
@@ -113,7 +113,7 @@ class SequenceClassificationModel(PyTorchIEModel):
         logits = self.classifier(pooled_output)
         return {"logits": logits}
 
-    def step(self, stage: str, batch: StepInputType):
+    def step(self, stage: str, batch: ModelStepInputType):
         input_, target = batch
         assert target is not None, "target has to be available for training"
 
@@ -129,13 +129,13 @@ class SequenceClassificationModel(PyTorchIEModel):
 
         return loss
 
-    def training_step(self, batch: StepInputType, batch_idx: int):
+    def training_step(self, batch: ModelStepInputType, batch_idx: int):
         return self.step(stage=TRAINING, batch=batch)
 
-    def validation_step(self, batch: StepInputType, batch_idx: int):
+    def validation_step(self, batch: ModelStepInputType, batch_idx: int):
         return self.step(stage=VALIDATION, batch=batch)
 
-    def test_step(self, batch: StepInputType, batch_idx: int):
+    def test_step(self, batch: ModelStepInputType, batch_idx: int):
         return self.step(stage=TEST, batch=batch)
 
     def configure_optimizers(self):

--- a/src/pie_models/models/sequence_classification.py
+++ b/src/pie_models/models/sequence_classification.py
@@ -87,7 +87,9 @@ class SequenceClassificationModel(PyTorchIEModel):
         self.f1 = nn.ModuleDict(
             {
                 f"stage_{stage}": torchmetrics.F1Score(
-                    num_classes=num_classes, ignore_index=ignore_index
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
+                    task="multilabel" if multi_label else "multiclass",
                 )
                 for stage in [TRAINING, VALIDATION, TEST]
             }

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -32,16 +32,14 @@ from pytorch_ie.annotations import (
 )
 from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
 from pytorch_ie.documents import TextDocument
-from pytorch_ie.models import (
-    TransformerTextClassificationModelBatchOutput,
-    TransformerTextClassificationModelStepBatchEncoding,
-)
 from pytorch_ie.utils.span import get_token_slice, is_contained_in
 from pytorch_ie.utils.window import get_window_around_slice
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 from typing_extensions import TypeAlias
+
+from pie_models.models.sequence_classification import ModelOutputType, ModelStepInputType
 
 InputEncodingType: TypeAlias = Dict[str, Any]
 TargetEncodingType: TypeAlias = Sequence[int]
@@ -63,8 +61,8 @@ TaskModuleType: TypeAlias = TaskModule[
     TextDocument,
     InputEncodingType,
     TargetEncodingType,
-    TransformerTextClassificationModelStepBatchEncoding,
-    TransformerTextClassificationModelBatchOutput,
+    ModelStepInputType,
+    ModelOutputType,
     TaskOutputType,
 ]
 
@@ -560,9 +558,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType):
 
         return target
 
-    def unbatch_output(
-        self, model_output: TransformerTextClassificationModelBatchOutput
-    ) -> Sequence[TaskOutputType]:
+    def unbatch_output(self, model_output: ModelOutputType) -> Sequence[TaskOutputType]:
         logits = model_output["logits"]
 
         output_label_probs = logits.sigmoid() if self.multi_label else logits.softmax(dim=-1)
@@ -625,9 +621,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType):
             if label != self.none_label:
                 yield self.relation_annotation, new_annotation
 
-    def collate(
-        self, task_encodings: Sequence[TaskEncodingType]
-    ) -> TransformerTextClassificationModelStepBatchEncoding:
+    def collate(self, task_encodings: Sequence[TaskEncodingType]) -> ModelStepInputType:
         input_features = [
             {"input_ids": task_encoding.inputs["input_ids"]} for task_encoding in task_encodings
         ]

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -39,7 +39,10 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 from typing_extensions import TypeAlias
 
-from pie_models.models.sequence_classification import ModelOutputType, ModelStepInputType
+from pie_models.models.sequence_classification import (
+    ModelOutputType,
+    ModelStepInputType,
+)
 
 InputEncodingType: TypeAlias = Dict[str, Any]
 TargetEncodingType: TypeAlias = Sequence[int]

--- a/tests/models/test_seqeunce_classification.py
+++ b/tests/models/test_seqeunce_classification.py
@@ -286,7 +286,7 @@ def model(monkeypatch, pooler_type, inputs, targets):
         pooler_type=pooler_type,
         batch_size=inputs["input_ids"].shape[0],
         seq_len=inputs["input_ids"].shape[1],
-        num_classes=max(targets) + 1,
+        num_classes=int(max(targets) + 1),
     )
 
 


### PR DESCRIPTION
use latest `pytorch-ie` which again uses `torchmetrics >= 1`, `pytorch-lightning >= 2`, latest `datasets` and `transformers`, see https://github.com/ChristophAlt/pytorch-ie/pull/323