### PR TITLE
implement parameter use_auto_model_for_sequence_classification 

### DIFF
--- a/src/pie_models/models/sequence_classification.py
+++ b/src/pie_models/models/sequence_classification.py
@@ -4,18 +4,25 @@ from typing import Any, Dict, MutableMapping, Optional, Tuple, Union
 import torchmetrics
 from pytorch_ie.core import PyTorchIEModel
 from torch import Tensor, nn
+from torch.nn import Parameter
 from torch.optim import AdamW
-from transformers import AutoConfig, AutoModel, get_linear_schedule_with_warmup
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForSequenceClassification,
+    get_linear_schedule_with_warmup,
+)
+from transformers.modeling_outputs import SequenceClassifierOutputWithPast
 from typing_extensions import TypeAlias
 
-from .components.pooler import get_pooler_and_output_size
+from .components.pooler import CLS_TOKEN, get_pooler_and_output_size
 
 # The input to the forward method of this model. It is passed to
 # the base transformer model. Can also contain additional arguments
 # for the pooler (these need to be prefixed with "pooler_").
 ModelInputType: TypeAlias = MutableMapping[str, Any]
 # A dict with a single key "logits".
-ModelOutputType: TypeAlias = Dict[str, Tensor]
+ModelOutputType: TypeAlias = SequenceClassifierOutputWithPast
 # This contains the input and target tensors for a single training step.
 ModelStepInputType: TypeAlias = Tuple[
     ModelInputType,  # input
@@ -50,6 +57,8 @@ class SequenceClassificationModel(PyTorchIEModel):
         multi_label: bool = False,
         pooler: Optional[Union[Dict[str, Any], str]] = None,
         freeze_base_model: bool = False,
+        use_auto_model_for_sequence_classification: bool = False,
+        base_model_prefix: str = "model",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -60,39 +69,61 @@ class SequenceClassificationModel(PyTorchIEModel):
         self.task_learning_rate = task_learning_rate
         self.warmup_proportion = warmup_proportion
         self.freeze_base_model = freeze_base_model
-
-        config = AutoConfig.from_pretrained(model_name_or_path)
-        if self.is_from_pretrained:
-            self.model = AutoModel.from_config(config=config)
-        else:
-            self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
-        self.model.resize_token_embeddings(tokenizer_vocab_size)
-
-        if self.freeze_base_model:
-            for param in self.model.parameters():
-                param.requires_grad = False
-
-        if classifier_dropout is None:
-            # Get the classifier dropout value from the Huggingface model config.
-            # This is a bit of a mess since some Configs use different variable names or change the semantics
-            # of the dropout (e.g. DistilBert has one dropout prob for QA and one for Seq classification, and a
-            # general one for embeddings, encoder and pooler).
-            classifier_dropout_attr = HF_MODEL_TYPE_TO_CLASSIFIER_DROPOUT_ATTRIBUTE.get(
-                config.model_type, "classifier_dropout"
-            )
-            classifier_dropout = getattr(config, classifier_dropout_attr) or 0.0
-        self.dropout = nn.Dropout(classifier_dropout)
+        self.use_auto_model_for_sequence_classification = (
+            use_auto_model_for_sequence_classification
+        )
+        self.base_model_prefix = base_model_prefix
 
         if isinstance(pooler, str):
             pooler = {"type": pooler}
         self.pooler_config = pooler or {}
-        self.pooler, pooler_output_dim = get_pooler_and_output_size(
-            config=self.pooler_config,
-            input_dim=config.hidden_size,
-        )
-        self.classifier = nn.Linear(pooler_output_dim, num_classes)
 
-        self.loss_fct = nn.BCEWithLogitsLoss() if multi_label else nn.CrossEntropyLoss()
+        if self.use_auto_model_for_sequence_classification:
+            config = AutoConfig.from_pretrained(model_name_or_path, num_labels=num_classes)
+            pooler_type = self.pooler_config.get("type", None)
+            if pooler_type is not None and pooler_type != CLS_TOKEN:
+                raise ValueError(
+                    f"pooler type must be '{CLS_TOKEN}' when using AutoModelForSequenceClassification"
+                )
+
+            if self.is_from_pretrained:
+                self.model = AutoModelForSequenceClassification.from_config(config=config)
+            else:
+                self.model = AutoModelForSequenceClassification.from_pretrained(
+                    model_name_or_path,
+                    config=config,
+                )
+        else:
+            config = AutoConfig.from_pretrained(model_name_or_path)
+            if self.is_from_pretrained:
+                self.model = AutoModel.from_config(config=config)
+            else:
+                self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
+
+            if classifier_dropout is None:
+                # Get the classifier dropout value from the Huggingface model config.
+                # This is a bit of a mess since some Configs use different variable names or change the semantics
+                # of the dropout (e.g. DistilBert has one dropout prob for QA and one for Seq classification, and a
+                # general one for embeddings, encoder and pooler).
+                classifier_dropout_attr = HF_MODEL_TYPE_TO_CLASSIFIER_DROPOUT_ATTRIBUTE.get(
+                    config.model_type, "classifier_dropout"
+                )
+                classifier_dropout = getattr(config, classifier_dropout_attr) or 0.0
+            self.dropout = nn.Dropout(classifier_dropout)
+
+            self.pooler, pooler_output_dim = get_pooler_and_output_size(
+                config=self.pooler_config,
+                input_dim=config.hidden_size,
+            )
+            self.classifier = nn.Linear(pooler_output_dim, num_classes)
+
+            self.loss_fct = nn.BCEWithLogitsLoss() if multi_label else nn.CrossEntropyLoss()
+
+        if self.freeze_base_model:
+            for _, param in self.base_model_named_parameters().items():
+                param.requires_grad = False
+
+        self.model.resize_token_embeddings(tokenizer_vocab_size)
 
         self.f1 = nn.ModuleDict(
             {
@@ -105,7 +136,26 @@ class SequenceClassificationModel(PyTorchIEModel):
             }
         )
 
+    def base_model_named_parameters(self) -> Dict[str, Parameter]:
+        if self.use_auto_model_for_sequence_classification:
+            result = {
+                f"model.{name}": param
+                for name, param in self.model.named_parameters()
+                if name.startswith(self.base_model_prefix)
+            }
+            if len(result) == 0:
+                raise ValueError(
+                    f"No base model parameters found. Is base_model_prefix={self.base_model_prefix} for "
+                    f"{type(self.model).__name__} correct?"
+                )
+        else:
+            result = dict(self.model.named_parameters(prefix="model"))
+        return result
+
     def forward(self, inputs: ModelInputType) -> ModelOutputType:
+        if self.use_auto_model_for_sequence_classification:
+            return self.model(**inputs)
+
         pooler_inputs = {}
         model_inputs = {}
         for k, v in inputs.items():
@@ -113,6 +163,8 @@ class SequenceClassificationModel(PyTorchIEModel):
                 pooler_inputs[k[len("pooler_") :]] = v
             else:
                 model_inputs[k] = v
+
+        labels = model_inputs.pop("labels", None)
 
         output = self.model(**model_inputs)
 
@@ -123,18 +175,24 @@ class SequenceClassificationModel(PyTorchIEModel):
         pooled_output = self.dropout(pooled_output)
 
         logits = self.classifier(pooled_output)
-        return {"logits": logits}
+        result = {"logits": logits}
+        if labels is not None:
+            loss = self.loss_fct(logits, labels)
+            result["loss"] = loss
+        return SequenceClassifierOutputWithPast(**result)
 
     def step(self, stage: str, batch: ModelStepInputType):
-        input_, target = batch
+        inputs, target = batch
         assert target is not None, "target has to be available for training"
 
-        logits = self(input_)["logits"]
-
-        loss = self.loss_fct(logits, target)
+        all_inputs = dict(inputs)
+        all_inputs["labels"] = target
+        output = self(all_inputs)
+        loss = output.loss
 
         self.log(f"{stage}/loss", loss, on_step=(stage == TRAINING), on_epoch=True, prog_bar=True)
 
+        logits = output.logits
         f1 = self.f1[f"stage_{stage}"]
         f1(logits, target)
         self.log(f"{stage}/f1", f1, on_step=False, on_epoch=True, prog_bar=True)
@@ -153,7 +211,7 @@ class SequenceClassificationModel(PyTorchIEModel):
     def configure_optimizers(self):
         if self.task_learning_rate is not None:
             all_params = dict(self.named_parameters())
-            base_model_params = dict(self.model.named_parameters(prefix="model"))
+            base_model_params = self.base_model_named_parameters()
             task_params = {k: v for k, v in all_params.items() if k not in base_model_params}
             optimizer = AdamW(
                 [

--- a/src/pie_models/models/sequence_classification.py
+++ b/src/pie_models/models/sequence_classification.py
@@ -59,6 +59,7 @@ class SequenceClassificationModel(PyTorchIEModel):
         freeze_base_model: bool = False,
         use_auto_model_for_sequence_classification: bool = False,
         base_model_prefix: str = "model",
+        model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,6 +74,7 @@ class SequenceClassificationModel(PyTorchIEModel):
             use_auto_model_for_sequence_classification
         )
         self.base_model_prefix = base_model_prefix
+        self.model_kwargs = model_kwargs or {}
 
         if isinstance(pooler, str):
             pooler = {"type": pooler}
@@ -88,21 +90,19 @@ class SequenceClassificationModel(PyTorchIEModel):
 
             if self.is_from_pretrained:
                 self.model = AutoModelForSequenceClassification.from_config(
-                    config=config, device_map="auto"
+                    config=config, **self.model_kwargs
                 )
             else:
                 self.model = AutoModelForSequenceClassification.from_pretrained(
-                    model_name_or_path,
-                    config=config,
-                    device_map="auto",
+                    model_name_or_path, config=config, **self.model_kwargs
                 )
         else:
             config = AutoConfig.from_pretrained(model_name_or_path)
             if self.is_from_pretrained:
-                self.model = AutoModel.from_config(config=config, device_map="auto")
+                self.model = AutoModel.from_config(config=config, **self.model_kwargs)
             else:
                 self.model = AutoModel.from_pretrained(
-                    model_name_or_path, config=config, device_map="auto"
+                    model_name_or_path, config=config, **self.model_kwargs
                 )
 
             if classifier_dropout is None:

--- a/src/pie_models/models/sequence_classification.py
+++ b/src/pie_models/models/sequence_classification.py
@@ -87,18 +87,23 @@ class SequenceClassificationModel(PyTorchIEModel):
                 )
 
             if self.is_from_pretrained:
-                self.model = AutoModelForSequenceClassification.from_config(config=config)
+                self.model = AutoModelForSequenceClassification.from_config(
+                    config=config, device_map="auto"
+                )
             else:
                 self.model = AutoModelForSequenceClassification.from_pretrained(
                     model_name_or_path,
                     config=config,
+                    device_map="auto",
                 )
         else:
             config = AutoConfig.from_pretrained(model_name_or_path)
             if self.is_from_pretrained:
-                self.model = AutoModel.from_config(config=config)
+                self.model = AutoModel.from_config(config=config, device_map="auto")
             else:
-                self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
+                self.model = AutoModel.from_pretrained(
+                    model_name_or_path, config=config, device_map="auto"
+                )
 
             if classifier_dropout is None:
                 # Get the classifier dropout value from the Huggingface model config.

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -270,6 +270,18 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType):
         }
 
         self.id_to_label = {v: k for k, v in self.label_to_id.items()}
+        if self.tokenizer.pad_token is None:
+            logger.warning(
+                "The tokenizer has no pad token, but this is required to pad the batches. We add a pad token to "
+                "the tokenizer."
+            )
+            self.tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+        if self.append_markers and self.tokenizer.sep_token is None:
+            logger.warning(
+                "The tokenizer has no sep token, but this is required if append_markers=True. We add a sep token "
+                "to the tokenizer."
+            )
+            self.tokenizer.add_special_tokens({"sep_token": "[SEP]"})
 
     def _create_relation_candidates(
         self,

--- a/tests/models/test_sequence_classification.py
+++ b/tests/models/test_sequence_classification.py
@@ -317,7 +317,7 @@ def get_model(
     monkeypatch.setattr(
         transformers.AutoModel,
         "from_pretrained",
-        lambda model_name_or_path, config: MockModel(
+        lambda model_name_or_path, device_map, config: MockModel(
             batch_size=batch_size,
             seq_len=seq_len,
             hidden_size=hidden_size,
@@ -328,7 +328,7 @@ def get_model(
     monkeypatch.setattr(
         transformers.AutoModelForSequenceClassification,
         "from_pretrained",
-        lambda model_name_or_path, config: MockSequenceModel(
+        lambda model_name_or_path, config, device_map: MockSequenceModel(
             batch_size=batch_size,
             seq_len=seq_len,
             hidden_size=hidden_size,

--- a/tests/models/test_sequence_classification.py
+++ b/tests/models/test_sequence_classification.py
@@ -317,7 +317,7 @@ def get_model(
     monkeypatch.setattr(
         transformers.AutoModel,
         "from_pretrained",
-        lambda model_name_or_path, device_map, config: MockModel(
+        lambda model_name_or_path, config: MockModel(
             batch_size=batch_size,
             seq_len=seq_len,
             hidden_size=hidden_size,
@@ -328,7 +328,7 @@ def get_model(
     monkeypatch.setattr(
         transformers.AutoModelForSequenceClassification,
         "from_pretrained",
-        lambda model_name_or_path, config, device_map: MockSequenceModel(
+        lambda model_name_or_path, config: MockSequenceModel(
             batch_size=batch_size,
             seq_len=seq_len,
             hidden_size=hidden_size,


### PR DESCRIPTION
... for `SequenceClassificationModel`. If enabled, `AutoModelForSequenceClassification` will be used instead of `AutoModel` + costume classification head (and pooler). 

Especially, this allows to fine-tune Llama models. Example call (for `pie-document-level`):
```
python src/train.py \
experiment=sciarg_relations \
taskmodule.tokenizer_name_or_path=TheBloke/Llama-2-7B-GPTQ \
taskmodule.max_window=2048 \
model.model_name_or_path=TheBloke/Llama-2-7B-GPTQ \
+model.use_auto_model_for_sequence_classification=true \
+model.freeze_base_model=true \
+model.model_kwargs.device_map=auto \
+model.model_kwargs.torch_dtype=auto \
trainer=gpu \
datamodule.batch_size=1
```
Notes: 
- This requires the recently implemented QPTQ integration for Huggingface `transformers`, see [here](https://huggingface.co/blog/gptq-integration#native-support-of-gptq-models-in-%F0%9F%A4%97-transformers), i.e.
  - [transformers>=4.32.0](https://github.com/huggingface/transformers/releases/tag/v4.32.0): `pip install transformers==4.32.1` 
  - [AutoQPTQ](https://github.com/PanQiWei/AutoGPTQ): `pip install auto-gptq`
  - Optimum: `pip install optimum`
  - requires to run on GPU!
-  `model.freeze_base_model=true` will **not** freeze the embedding layer (we resize the embedding layer after freezing the base model which unfreezes the embedding layer again)

EDIT: Not sure, if that really learns sth... the loss is nan, at least for the first >6k steps.