### PR TITLE
use interface classes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie >= 0.18.0",
+    # "pytorch-ie >= 0.18.0",
+    # requires:
+    # - https://github.com/ChristophAlt/pytorch-ie/pull/328 add model and taskmodule Interface classes
+    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@interface_classes",
     "torchmetrics >= 0.11.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    # "pytorch-ie >= 0.18.0",
-    # requires:
-    # - https://github.com/ChristophAlt/pytorch-ie/pull/328 add model and taskmodule Interface classes
-    "pytorch-ie @ git+https://github.com/ChristophAlt/pytorch-ie.git@interface_classes",
+    "pytorch-ie >= 0.22.0",
     "torchmetrics >= 0.11.0",
 ]
 

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -32,6 +32,7 @@ from pytorch_ie.annotations import (
 )
 from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
 from pytorch_ie.documents import TextDocument
+from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from pytorch_ie.utils.span import get_token_slice, is_contained_in
 from pytorch_ie.utils.window import get_window_around_slice
 from transformers import AutoTokenizer
@@ -127,7 +128,7 @@ class RelationArgument:
 
 
 @TaskModule.register()
-class RETextClassificationWithIndicesTaskModule(TaskModuleType):
+class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizerVocabSize):
     """Marker based relation extraction. This taskmodule prepares the input token ids in such a way
     that before and after the candidate head and tail entities special marker tokens are inserted.
     Then, the modified token ids can be simply passed into a transformer based text classifier


### PR DESCRIPTION
This integrates the interface classes introduced in https://github.com/ChristophAlt/pytorch-ie/pull/328.

Note: This also makes the parameter `tokenizer_vocab_size` optional for the `SequenceClassificationModel`.

