### PR TITLE
Update pytorch ie 0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie >= 0.22.0",
+    "pytorch-ie >= 0.23.0",
     "torchmetrics >= 0.11.0",
 ]
 

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -17,6 +17,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypedDict,
     Union,
 )
@@ -31,7 +32,11 @@ from pytorch_ie.annotations import (
     Span,
 )
 from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import (
+    TextDocument,
+    TextDocumentWithLabeledEntitiesAndRelations,
+    TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions,
+)
 from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from pytorch_ie.utils.span import get_token_slice, is_contained_in
 from pytorch_ie.utils.window import get_window_around_slice
@@ -212,6 +217,13 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         self.argument_markers = None
 
         self._logged_examples_counter = 0
+
+    @property
+    def document_type(self) -> Optional[Type[TextDocument]]:
+        if self.partition_annotation is not None:
+            return TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions
+        else:
+            return TextDocumentWithLabeledEntitiesAndRelations
 
     def get_relation_layer(self, document: Document) -> AnnotationList[BinaryRelation]:
         return document[self.relation_annotation]


### PR DESCRIPTION
Especially, this implements `RETextClassificationWithIndicesTaskModule.document_type`.