### PR TITLE
add reversed relations and filter relations by argument distance (`RETextClassificationWithIndicesTaskModule`)

### DIFF
--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -535,6 +535,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                 for entity in all_entities
                 if is_contained_in((entity.start, entity.end), (partition.start, partition.end))
             ]
+            # filter relations that have arguments in the current partition
             entities_set = set(entities)
             relations: Sequence[Annotation] = [
                 rel
@@ -570,15 +571,6 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                         f"the taskmodule expects the relation arguments to be of type LabeledSpan, "
                         f"but got {[type(arg) for arg in arg_spans]}"
                     )
-
-                # check if all argument spans are in the current partition
-                if any(
-                    not is_contained_in((arg.start, arg.end), (partition.start, partition.end))
-                    for arg in arg_spans
-                ):
-                    # TODO: add test case for this
-                    self.increase_counter(key=("skipped_args_not_in_partition", rel.label))
-                    continue
 
                 # map character spans to token spans
                 arg_token_slices_including_none = [

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -347,7 +347,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             rel_args = get_relation_arguments(rel)
             if rel_args in rel_args_to_relation:
                 prev_label = rel_args_to_relation[rel_args].label
-                raise ValueError(
+                logger.warning(
                     f"doc.id={doc_id}: there are multiple relations with the same arguments {rel_args}: "
                     f"previous label='{prev_label}' and current label='{rel.label}'"
                 )

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -591,8 +591,10 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                 # Check if the mapping was successful. It may fail (and is None) if any argument start or end does not
                 # match a token start or end, respectively.
                 if any(token_slice is None for token_slice in arg_token_slices_including_none):
+                    arg_spans_dict = {arg_span: str(arg_span) for arg_span in arg_spans}
                     logger.warning(
-                        f"Skipping invalid example {document.id}, cannot get argument token slice(s)"
+                        f"doc.id={document.id}: Skipping invalid example, cannot get argument token slices for "
+                        f"{arg_spans_dict}"
                     )
                     self.increase_counter(key=("skipped_args_not_aligned", rel.label))
                     continue

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -282,7 +282,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             relation_labels.remove(self.none_label)
 
         if self.add_reversed_relations:
-            for rel_label in relation_labels:
+            for rel_label in set(relation_labels):
                 if rel_label.endswith(self.reversed_relation_label_suffix):
                     raise ValueError(
                         f"the relation label '{rel_label}' already ends with the reversed_relation_label_suffix "

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -326,7 +326,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             to_show = pd.Series(self._statistics)
             if len(to_show.index.names) > 1:
                 to_show = to_show.unstack()
-            logger.info(f"statistics:\n{to_show}")
+            logger.info(f"statistics:\n{to_show.to_markdown()}")
 
     def increase_counter(self, key: Tuple[Any, ...], value: Optional[int] = 1):
         if self.show_statistics:

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -527,6 +527,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             # use single dummy partition
             partitions = [Span(start=0, end=len(document.text))]
 
+        used_relations: List[Annotation] = []
         task_encodings: List[TaskEncodingType] = []
         for partition in partitions:
             entities: List[Span] = [
@@ -743,6 +744,11 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                     )
                 )
                 self.increase_counter(key=("used", rel.label))
+                used_relations.append(rel)
+
+        not_used_relations = set(all_relations) - set(used_relations)
+        for rel in not_used_relations:
+            self.increase_counter(key=("skipped_not_used", rel.label))
 
         return task_encodings
 

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -157,6 +157,17 @@ class RelationArgument:
         )
 
 
+def get_relation_arguments(relation: Annotation) -> Tuple[Annotation, ...]:
+    if isinstance(relation, BinaryRelation):
+        return (relation.head, relation.tail)
+    elif isinstance(relation, NaryRelation):
+        return tuple(relation.arguments)
+    else:
+        raise NotImplementedError(
+            f"the taskmodule does not yet support getting relation arguments for type: {type(relation)}"
+        )
+
+
 @TaskModule.register()
 class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizerVocabSize):
     """Marker based relation extraction. This taskmodule prepares the input token ids in such a way
@@ -328,26 +339,52 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
 
         self.id_to_label = {v: k for k, v in self.label_to_id.items()}
 
-    def _add_reversed_relations(self, relations: Sequence[Annotation]) -> List[BinaryRelation]:
-        with_reversed_relations: List[BinaryRelation] = []
+    def _add_reversed_relations(self, relations: Sequence[Annotation]) -> List[Annotation]:
+        with_reversed_relations: List[Annotation] = []
+        rel_args_to_relation: Dict[Tuple[Annotation, ...], BinaryRelation] = {}
         for rel in relations:
-            if isinstance(rel, BinaryRelation):
-                with_reversed_relations.append(rel)
+            rel_args = get_relation_arguments(rel)
+            if rel_args in rel_args_to_relation:
+                prev_label = rel_args_to_relation[rel_args].label
+                raise ValueError(
+                    f"there are multiple labels for the relation arguments {rel_args}: {prev_label} and {rel.label}"
+                )
+            rel_args_to_relation[rel_args] = rel
+        for rel in relations:
+            with_reversed_relations.append(rel)
 
-                label = rel.label
-                if rel.label not in self.symmetric_relations:
-                    label += self.reversed_relation_label_suffix
-                reversed_rel = BinaryRelation(
-                    head=rel.tail,
-                    tail=rel.head,
-                    label=label,
-                    score=rel.score,
+            label = rel.label
+            if label.endswith(self.reversed_relation_label_suffix):
+                logger.warning(
+                    f"the relation has the label '{label}' which already ends with the "
+                    f"reversed_relation_label_suffix='{self.reversed_relation_label_suffix}', "
+                    f"do not add a reversed relation for it"
                 )
-                with_reversed_relations.append(reversed_rel)
             else:
-                raise NotImplementedError(
-                    f"the taskmodule does not yet support adding reversed relations for type: {type(rel)}"
-                )
+                rel_args = get_relation_arguments(rel)
+                if isinstance(rel, BinaryRelation):
+                    rel_args_reversed = (rel_args[1], rel_args[0])
+                    if rel.label not in self.symmetric_relations:
+                        label += self.reversed_relation_label_suffix
+                    if rel_args_reversed in rel_args_to_relation:
+                        prev_label = rel_args_to_relation[rel_args_reversed].label
+                        raise ValueError(
+                            f"can not add the reversed relation with arguments={rel_args_reversed} and label={label} "
+                            f"because there is already a relation with label {prev_label} for these arguments"
+                        )
+
+                    reversed_rel = BinaryRelation(
+                        head=rel.tail,
+                        tail=rel.head,
+                        label=label,
+                        score=rel.score,
+                    )
+                    with_reversed_relations.append(reversed_rel)
+                    rel_args_to_relation[rel_args_reversed] = reversed_rel
+                else:
+                    raise NotImplementedError(
+                        f"the taskmodule does not yet support adding reversed relations for type: {type(rel)}"
+                    )
 
         return with_reversed_relations
 

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -722,12 +722,15 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             if isinstance(candidate_annotation, BinaryRelation):
                 head = candidate_annotation.head
                 tail = candidate_annotation.tail
-                # reverse any predicted reversed relations back
-                if self.add_reversed_relations and label.endswith(
-                    self.reversed_relation_label_suffix
-                ):
-                    label = label[: -len(self.reversed_relation_label_suffix)]
-                    head, tail = tail, head
+                # Reverse predicted reversed relations back. Serialization will remove any duplicated relations.
+                if self.add_reversed_relations:
+                    if label.endswith(self.reversed_relation_label_suffix):
+                        label = label[: -len(self.reversed_relation_label_suffix)]
+                        head, tail = tail, head
+                    # If the predicted label is symmetric, we sort the arguments by its center.
+                    elif label in self.symmetric_relations:
+                        if (head.start + head.end) / 2 < (tail.start + tail.end) / 2:
+                            head, tail = tail, head
                 new_annotation = BinaryRelation(
                     head=head, tail=tail, label=label, score=probability
                 )

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -553,7 +553,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                             f"occurring relation which has the label='{prev_label}'."
                         )
                         if self.collect_statistics:
-                            self.increase_counter(("skipped_same_arguments", rel.label))
+                            skipped_relations["skipped_same_arguments"].append(rel.label)
                     else:
                         arguments2relation[arguments] = rel
 

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -333,15 +333,17 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         for rel in relations:
             if isinstance(rel, BinaryRelation):
                 with_reversed_relations.append(rel)
+
+                label = rel.label
                 if rel.label not in self.symmetric_relations:
-                    with_reversed_relations.append(
-                        BinaryRelation(
-                            head=rel.tail,
-                            tail=rel.head,
-                            label=rel.label + self.reversed_relation_label_suffix,
-                            score=rel.score,
-                        )
-                    )
+                    label += self.reversed_relation_label_suffix
+                reversed_rel = BinaryRelation(
+                    head=rel.tail,
+                    tail=rel.head,
+                    label=label,
+                    score=rel.score,
+                )
+                with_reversed_relations.append(reversed_rel)
             else:
                 raise NotImplementedError(
                     f"the taskmodule does not yet support adding reversed relations for type: {type(rel)}"

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -729,6 +729,13 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                         head, tail = tail, head
                     # If the predicted label is symmetric, we sort the arguments by its center.
                     elif label in self.symmetric_relations:
+                        if not (isinstance(head, Span) and isinstance(tail, Span)):
+                            raise ValueError(
+                                f"the taskmodule expects the relation arguments of the candidate_annotation"
+                                f"to be of type Span, but got head of type: {type(head)} and tail of type: "
+                                f"{type(tail)}"
+                            )
+                        # swap head and tail if the center of head is larger than the center of tail
                         if (head.start + head.end) / 2 < (tail.start + tail.end) / 2:
                             head, tail = tail, head
                 new_annotation = BinaryRelation(

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -370,11 +370,12 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                 rel_args_reversed = (rel_args[1], rel_args[0])
                 if rel_args_reversed in rel_args_to_relation:
                     prev_label = rel_args_to_relation[rel_args_reversed].label
-                    raise ValueError(
-                        f"doc.id={doc_id}: can not add the reversed relation with arguments={rel_args_reversed} and "
-                        f"label={label} because there is already a relation with label {prev_label} for "
-                        f"these arguments"
+                    logger.warning(
+                        f"doc.id={doc_id}: there is already a relation with reversed arguments={rel_args_reversed} "
+                        f"and label={prev_label}, so we do not add the reversed relation (with label {prev_label}) "
+                        f"for these arguments"
                     )
+                    continue
 
                 reversed_rel = BinaryRelation(
                     head=rel.tail,

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -553,7 +553,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                             f"occurring relation which has the label='{prev_label}'."
                         )
                         if self.collect_statistics:
-                            skipped_relations["skipped_same_arguments"].append(rel.label)
+                            skipped_relations["skipped_same_arguments"].append(rel)
                     else:
                         arguments2relation[arguments] = rel
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+import pkg_resources
 import pytest
 from datasets import load_dataset
 from pytorch_ie import DatasetDict
@@ -8,6 +9,8 @@ from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextBasedDocument
 
 from tests import FIXTURES_ROOT
+
+_TABULATE_AVAILABLE = "tabulate" in {pkg.key for pkg in pkg_resources.working_set}
 
 
 @dataclasses.dataclass

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -1275,7 +1275,9 @@ def test_encode_with_unaligned_span(caplog):
     assert caplog.records[0].levelname == "WARNING"
     assert (
         caplog.records[0].message
-        == "Skipping invalid example doc1, cannot get argument token slice(s)"
+        == "doc.id=doc1: Skipping invalid example, cannot get argument token slices for "
+           "{LabeledSpan(start=0, end=5, label='a', score=1.0): 'hello', "
+           "LabeledSpan(start=7, end=13, label='a', score=1.0): ' space'}"
     )
 
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -1276,8 +1276,8 @@ def test_encode_with_unaligned_span(caplog):
     assert (
         caplog.records[0].message
         == "doc.id=doc1: Skipping invalid example, cannot get argument token slices for "
-           "{LabeledSpan(start=0, end=5, label='a', score=1.0): 'hello', "
-           "LabeledSpan(start=7, end=13, label='a', score=1.0): ' space'}"
+        "{LabeledSpan(start=0, end=5, label='a', score=1.0): 'hello', "
+        "LabeledSpan(start=7, end=13, label='a', score=1.0): ' space'}"
     )
 
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -857,7 +857,7 @@ def test_encode_with_create_relation_candidates(documents):
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path,
-        create_relation_candidates=True,
+        add_candidate_relations=True,
     )
     taskmodule.prepare(documents)
     documents_without_relations = []

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -18,7 +18,7 @@ from pie_models.taskmodules.re_text_classification_with_indices import (
     span_distance,
 )
 from tests import _config_to_str
-from tests.conftest import TestDocument
+from tests.conftest import _TABULATE_AVAILABLE, TestDocument
 
 CONFIGS = [
     {"add_type_to_marker": False, "append_markers": False},
@@ -767,20 +767,30 @@ def test_encode_with_windowing(documents):
     ]
 
 
-@pytest.mark.parametrize("add_argument_indices_to_input", [False, True])
-def test_encode_with_add_argument_indices(documents, add_argument_indices_to_input):
+@pytest.fixture(scope="module", params=[False, True])
+def encodings_and_taskmodule_with_argument_indices(request, documents):
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path,
-        add_argument_indices_to_input=add_argument_indices_to_input,
+        add_argument_indices_to_input=request.param,
     )
 
     assert not taskmodule.is_from_pretrained
     taskmodule.prepare(documents)
     task_encodings = taskmodule.encode(documents)
     assert len(task_encodings) == 7
+    return task_encodings, taskmodule
 
-    encoding = task_encodings[0]
+
+def test_encode_with_add_argument_indices(encodings_and_taskmodule_with_argument_indices):
+    encodings, taskmodule = encodings_and_taskmodule_with_argument_indices
+    if taskmodule.add_argument_indices_to_input:
+        assert all(["pooler_start_indices" in encoding.inputs for encoding in encodings])
+        assert all(["pooler_end_indices" in encoding.inputs for encoding in encodings])
+    else:
+        assert not any(["pooler_start_indices" in encoding.inputs for encoding in encodings])
+        assert not any(["pooler_end_indices" in encoding.inputs for encoding in encodings])
+    encoding = encodings[0]
     if taskmodule.add_argument_indices_to_input:
         assert "pooler_start_indices" in encoding.inputs
         assert "pooler_end_indices" in encoding.inputs
@@ -793,7 +803,7 @@ def test_encode_with_add_argument_indices(documents, add_argument_indices_to_inp
         assert "pooler_start_indices" not in encoding.inputs
         assert "pooler_end_indices" not in encoding.inputs
 
-    encoding = task_encodings[3]
+    encoding = encodings[3]
     if taskmodule.add_argument_indices_to_input:
         assert "pooler_start_indices" in encoding.inputs
         assert "pooler_end_indices" in encoding.inputs
@@ -807,29 +817,15 @@ def test_encode_with_add_argument_indices(documents, add_argument_indices_to_inp
         assert "pooler_end_indices" not in encoding.inputs
 
 
-@pytest.mark.parametrize("add_argument_indices_to_input", [False, True])
-def test_collate_with_add_argument_indices(documents, add_argument_indices_to_input):
-    tokenizer_name_or_path = "bert-base-cased"
-    taskmodule = RETextClassificationWithIndicesTaskModule(
-        tokenizer_name_or_path=tokenizer_name_or_path,
-        add_argument_indices_to_input=add_argument_indices_to_input,
-    )
-    taskmodule.prepare(documents)
-    encodings = taskmodule.encode(documents)
-    if add_argument_indices_to_input:
-        assert all(["pooler_start_indices" in encoding.inputs for encoding in encodings])
-        assert all(["pooler_end_indices" in encoding.inputs for encoding in encodings])
-    else:
-        assert not any(["pooler_start_indices" in encoding.inputs for encoding in encodings])
-        assert not any(["pooler_end_indices" in encoding.inputs for encoding in encodings])
-
+def test_collate_with_add_argument_indices(encodings_and_taskmodule_with_argument_indices):
+    encodings, taskmodule = encodings_and_taskmodule_with_argument_indices
     batch_encoding = taskmodule.collate(encodings[:2])
     inputs, targets = batch_encoding
 
     assert "input_ids" in inputs
     assert "attention_mask" in inputs
     assert inputs["input_ids"].shape == inputs["attention_mask"].shape
-    if add_argument_indices_to_input:
+    if taskmodule.add_argument_indices_to_input:
         assert "pooler_start_indices" in inputs
         assert "pooler_end_indices" in inputs
 
@@ -843,16 +839,51 @@ def test_collate_with_add_argument_indices(documents, add_argument_indices_to_in
         assert "pooler_end_indices" not in inputs
 
 
-def test_relation_argument_role_unknown(documents):
-    tokenizer_name_or_path = "bert-base-cased"
+def test_encode_input_multiple_relations_for_same_arguments(caplog):
     taskmodule = RETextClassificationWithIndicesTaskModule(
-        tokenizer_name_or_path=tokenizer_name_or_path,
+        tokenizer_name_or_path="bert-base-cased",
+    )
+    document = TestDocument(text="A founded B.", id="multiple_relations_for_same_arguments")
+    document.entities.append(LabeledSpan(start=0, end=1, label="PER"))
+    document.entities.append(LabeledSpan(start=10, end=11, label="PER"))
+    entities = document.entities
+    assert str(entities[0]) == "A"
+    assert str(entities[1]) == "B"
+    document.relations.extend(
+        [
+            BinaryRelation(head=entities[0], tail=entities[1], label="per:founded_by"),
+            BinaryRelation(head=entities[0], tail=entities[1], label="per:founder"),
+        ]
+    )
+    taskmodule.prepare([document])
+    encodings = taskmodule.encode_input(document)
+
+    assert len(caplog.messages) == 1
+    assert (
+        caplog.messages[0]
+        == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
+        "(('head', LabeledSpan(start=0, end=1, label='PER', score=1.0)), "
+        "('tail', LabeledSpan(start=10, end=11, label='PER', score=1.0))): previous label='per:founded_by' "
+        "and current label='per:founder'. We only keep the first occurring relation which has the "
+        "label='per:founded_by'."
+    )
+
+    assert len(encodings) == 1
+    relation = encodings[0].metadata["candidate_annotation"]
+    assert str(relation.head) == "A"
+    assert str(relation.tail) == "B"
+    assert relation.label == "per:founded_by"
+
+
+def test_encode_input_argument_role_unknown(documents):
+    taskmodule = RETextClassificationWithIndicesTaskModule(
+        tokenizer_name_or_path="bert-base-cased",
         # the tail argument is not in the role_to_marker
         argument_role_to_marker={HEAD: "H"},
     )
     taskmodule.prepare(documents)
     with pytest.raises(ValueError) as excinfo:
-        task_encodings = taskmodule.encode(documents)
+        taskmodule.encode_input(documents[1])
     assert (
         str(excinfo.value)
         == "role=tail not in role_to_marker={'head': 'H'} (did you initialise the taskmodule with "
@@ -861,9 +892,8 @@ def test_relation_argument_role_unknown(documents):
 
 
 def test_encode_input_with_add_candidate_relations(documents):
-    tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
-        tokenizer_name_or_path=tokenizer_name_or_path,
+        tokenizer_name_or_path="bert-base-cased",
         add_candidate_relations=True,
     )
     taskmodule.prepare(documents)
@@ -879,43 +909,25 @@ def test_encode_input_with_add_candidate_relations(documents):
             doc_without_relations.relations.append(relations[0])
         documents_without_relations.append(doc_without_relations)
         encodings.extend(taskmodule.encode(doc_without_relations))
+
     assert len(encodings) == 4
+    relations = [encoding.metadata["candidate_annotation"] for encoding in encodings]
+    texts = [encoding.document.text for encoding in encodings]
+    relation_tuples = [(str(rel.head), rel.label, str(rel.tail)) for rel in relations]
 
     # There are no entities in the first document, so there are no created relation candidates
 
     # this relation was kept
-    encoding = encodings[0]
-    assert encoding.document == documents_without_relations[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "Entity A"
-    assert str(relation.tail) == "B"
-    assert relation.label == "per:employee_of"
+    assert texts[0] == "Entity A works at B."
+    assert relation_tuples[0] == ("Entity A", "per:employee_of", "B")
 
     # the following relations were added
-    encoding = encodings[1]
-    assert encoding.document == documents_without_relations[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "B"
-    assert str(relation.tail) == "Entity A"
-    assert relation.label == "no_relation"
-
-    encoding = encodings[2]
-    assert encoding.document == documents_without_relations[2]
-    assert encoding.document.text == "Entity C and D."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "Entity C"
-    assert str(relation.tail) == "D"
-    assert relation.label == "no_relation"
-
-    encoding = encodings[3]
-    assert encoding.document == documents_without_relations[2]
-    assert encoding.document.text == "Entity C and D."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "D"
-    assert str(relation.tail) == "Entity C"
-    assert relation.label == "no_relation"
+    assert texts[1] == "Entity A works at B."
+    assert relation_tuples[1] == ("B", "no_relation", "Entity A")
+    assert texts[2] == "Entity C and D."
+    assert relation_tuples[2] == ("Entity C", "no_relation", "D")
+    assert texts[3] == "Entity C and D."
+    assert relation_tuples[3] == ("D", "no_relation", "Entity C")
 
 
 @pytest.fixture
@@ -952,7 +964,7 @@ def test_encode_input_with_add_candidate_relations_with_wrong_relation_type(
     )
     taskmodule.prepare([doc])
     with pytest.raises(NotImplementedError) as excinfo:
-        encodings = taskmodule.encode_input(doc)
+        taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
         == "doc.id=doc_with_nary_relations: the taskmodule does not yet support adding relation candidates "
@@ -973,26 +985,41 @@ def test_encode_input_with_add_reversed_relations(documents):
         encodings.extend(taskmodule.encode_input(doc))
 
     assert len(encodings) == 2
+    texts = [encoding.document.text for encoding in encodings]
+    relations = [encoding.metadata["candidate_annotation"] for encoding in encodings]
+    relation_tuples = [(str(rel.head), rel.label, str(rel.tail)) for rel in relations]
 
     # There are no relations in the first and last document, so there are also no new reversed relations
 
     # this is the original relation
-    encoding = encodings[0]
-    assert encoding.document == documents[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "Entity A"
-    assert str(relation.tail) == "B"
-    assert relation.label == "per:employee_of"
+    assert texts[0] == "Entity A works at B."
+    assert relation_tuples[0] == ("Entity A", "per:employee_of", "B")
 
     # this is the reversed relation
-    encoding = encodings[1]
-    assert encoding.document == documents[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "B"
-    assert str(relation.tail) == "Entity A"
-    assert relation.label == "per:employee_of_reversed"
+    assert texts[1] == "Entity A works at B."
+    assert relation_tuples[1] == ("B", "per:employee_of_reversed", "Entity A")
+
+    # test that an already reversed relation is not reversed again
+    document = TestDocument(
+        text="Entity A works at B.", id="doc_with_relation_with_reversed_suffix"
+    )
+    document.entities.extend(
+        [LabeledSpan(start=0, end=8, label="PER"), LabeledSpan(start=18, end=19, label="PER")]
+    )
+    document.relations.append(
+        BinaryRelation(
+            head=document.entities[1],
+            tail=document.entities[0],
+            label=f"per:employee_of{taskmodule.reversed_relation_label_suffix}",
+        )
+    )
+    with pytest.raises(ValueError) as excinfo:
+        taskmodule.encode_input(document)
+    assert str(excinfo.value) == (
+        "doc.id=doc_with_relation_with_reversed_suffix: The relation has the label 'per:employee_of_reversed' "
+        "which already ends with the reversed_relation_label_suffix='_reversed'. It looks like the relation is "
+        "already reversed, which is not allowed."
+    )
 
 
 def test_prepare_with_add_reversed_relations_with_label_has_suffix():
@@ -1025,40 +1052,128 @@ def test_prepare_with_add_reversed_relations_with_label_has_suffix():
     )
 
 
-def test_encode_input_with_add_reversed_relations_with_symmetric_relations(documents):
+@pytest.mark.parametrize("reverse_symmetric_relations", [False, True])
+def test_encode_input_with_add_reversed_relations_with_symmetric_relations(
+    reverse_symmetric_relations, caplog
+):
+    document = TestDocument(
+        text="Entity A is married with B, but likes C, who is married with D.",
+        id="doc_with_symmetric_relation",
+    )
+    document.entities.extend(
+        [
+            LabeledSpan(start=0, end=8, label="PER"),
+            LabeledSpan(start=25, end=26, label="PER"),
+            LabeledSpan(start=38, end=39, label="PER"),
+            LabeledSpan(start=61, end=62, label="PER"),
+        ]
+    )
+    assert str(document.entities[0]) == "Entity A"
+    assert str(document.entities[1]) == "B"
+    assert str(document.entities[2]) == "C"
+    assert str(document.entities[3]) == "D"
+    document.relations.extend(
+        [
+            BinaryRelation(
+                head=document.entities[0], tail=document.entities[1], label="per:is_married_with"
+            ),
+            BinaryRelation(
+                head=document.entities[0], tail=document.entities[2], label="per:likes"
+            ),
+            BinaryRelation(
+                head=document.entities[2], tail=document.entities[3], label="per:is_married_with"
+            ),
+            BinaryRelation(
+                head=document.entities[3], tail=document.entities[2], label="per:is_married_with"
+            ),
+        ]
+    )
+
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path,
         add_reversed_relations=True,
-        symmetric_relations=["per:employee_of"],
+        symmetric_relations=["per:is_married_with"],
+        reverse_symmetric_relations=reverse_symmetric_relations,
     )
-    taskmodule.prepare(documents)
-    encodings = []
-    # just take the first three documents
-    for doc in documents[:3]:
-        encodings.extend(taskmodule.encode_input(doc))
+    taskmodule.prepare([document])
+    encodings = taskmodule.encode_input(document)
+    relations = [encoding.metadata["candidate_annotation"] for encoding in encodings]
+    relation_tuples = [
+        (str(relation.head), relation.label, str(relation.tail)) for relation in relations
+    ]
+    if reverse_symmetric_relations:
+        assert relation_tuples == [
+            ("Entity A", "per:is_married_with", "B"),
+            ("Entity A", "per:likes", "C"),
+            ("C", "per:is_married_with", "D"),
+            ("D", "per:is_married_with", "C"),
+            ("B", "per:is_married_with", "Entity A"),
+            ("C", "per:likes_reversed", "Entity A"),
+        ]
+        assert len(caplog.messages) == 2
+        assert (
+            caplog.messages[0]
+            == "doc.id=doc_with_symmetric_relation: there is already a relation with reversed "
+            "arguments=(('head', LabeledSpan(start=61, end=62, label='PER', score=1.0)), "
+            "('tail', LabeledSpan(start=38, end=39, label='PER', score=1.0))) and label=per:is_married_with, "
+            "so we do not add the reversed relation (with label per:is_married_with) for these arguments"
+        )
+        assert (
+            caplog.messages[1]
+            == "doc.id=doc_with_symmetric_relation: there is already a relation with reversed "
+            "arguments=(('head', LabeledSpan(start=38, end=39, label='PER', score=1.0)), "
+            "('tail', LabeledSpan(start=61, end=62, label='PER', score=1.0))) and label=per:is_married_with, "
+            "so we do not add the reversed relation (with label per:is_married_with) for these arguments"
+        )
+    else:
+        assert relation_tuples == [
+            ("Entity A", "per:is_married_with", "B"),
+            ("Entity A", "per:likes", "C"),
+            ("C", "per:is_married_with", "D"),
+            ("D", "per:is_married_with", "C"),
+            ("C", "per:likes_reversed", "Entity A"),
+        ]
+        assert len(caplog.messages) == 0
 
-    assert len(encodings) == 2
-
-    # There are no relations in the first and last document, so there are also no new reversed relations
-
-    # this is the original relation
-    encoding = encodings[0]
-    assert encoding.document == documents[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "Entity A"
-    assert str(relation.tail) == "B"
-    assert relation.label == "per:employee_of"
-
-    # this is the reversed relation
-    encoding = encodings[1]
-    assert encoding.document == documents[1]
-    assert encoding.document.text == "Entity A works at B."
-    relation = encoding.metadata["candidate_annotation"]
-    assert str(relation.head) == "B"
-    assert str(relation.tail) == "Entity A"
-    assert relation.label == "per:employee_of"
+    caplog.clear()
+    document = TestDocument(
+        text="Entity A is married with B.",
+        id="doc_with_reversed_symmetric_relation",
+    )
+    document.entities.append(LabeledSpan(start=0, end=8, label="PER"))
+    document.entities.append(LabeledSpan(start=25, end=26, label="PER"))
+    document.relations.append(
+        BinaryRelation(
+            head=document.entities[1], tail=document.entities[0], label="per:is_married_with"
+        )
+    )
+    encodings = taskmodule.encode_input(document)
+    relations = [encoding.metadata["candidate_annotation"] for encoding in encodings]
+    relation_tuples = [
+        (str(relation.head), relation.label, str(relation.tail)) for relation in relations
+    ]
+    if reverse_symmetric_relations:
+        assert len(relation_tuples) == 2
+        assert relation_tuples[0] == ("B", "per:is_married_with", "Entity A")
+        assert relation_tuples[1] == ("Entity A", "per:is_married_with", "B")
+        assert len(caplog.messages) == 1
+        assert (
+            caplog.messages[0]
+            == "doc.id=doc_with_reversed_symmetric_relation: The symmetric relation with label 'per:is_married_with' "
+            "has arguments (('head', LabeledSpan(start=25, end=26, label='PER', score=1.0)), "
+            "('tail', LabeledSpan(start=0, end=8, label='PER', score=1.0))) which are not sorted by their start "
+            "and end positions. This may lead to problems during evaluation because we assume that the arguments "
+            "of symmetric relations were sorted in the beginning and, thus, interpret relations where this is not "
+            "the case as reversed. All reversed relations will get their arguments swapped during inference in "
+            "the case of add_reversed_relations=True to remove duplicates. You may consider adding reversed "
+            "versions of the *symmetric* relations on your own and then setting *reverse_symmetric_relations* "
+            "to False."
+        )
+    else:
+        assert len(relation_tuples) == 1
+        assert relation_tuples[0] == ("B", "per:is_married_with", "Entity A")
+        assert len(caplog.messages) == 0
 
 
 def test_encode_input_with_add_reversed_relations_with_wrong_relation_type(
@@ -1072,7 +1187,7 @@ def test_encode_input_with_add_reversed_relations_with_wrong_relation_type(
     )
     taskmodule.prepare([doc])
     with pytest.raises(NotImplementedError) as excinfo:
-        encodings = taskmodule.encode_input(doc)
+        taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
         == "doc.id=doc_with_nary_relations: the taskmodule does not yet support adding "
@@ -1301,9 +1416,9 @@ def test_encode_with_log_first_n_examples(caplog):
     taskmodule.prepare([doc])
 
     # we need to set the log level to INFO, otherwise the log messages are not captured
-    caplog.set_level(logging.INFO)
     with caplog.at_level(logging.INFO):
         task_encodings = taskmodule.encode([doc, doc], encode_target=True)
+
     # the second example is skipped because log_first_n_examples=1
     assert len(task_encodings) == 2
     assert len(caplog.records) == 5
@@ -1313,3 +1428,23 @@ def test_encode_with_log_first_n_examples(caplog):
     assert caplog.records[2].message == "tokens: [CLS] [H] hello [/H] [T] world [/T] [SEP]"
     assert caplog.records[3].message == "input_ids: 101 28998 19082 28996 28999 1362 28997 102"
     assert caplog.records[4].message == "Expected label: ['rel'] (ids = [1])"
+
+
+@pytest.mark.skipif(condition=not _TABULATE_AVAILABLE, reason="requires the 'tabulate' package")
+def test_encode_with_collect_statistics(documents, caplog):
+    taskmodule = RETextClassificationWithIndicesTaskModule(
+        tokenizer_name_or_path="bert-base-cased",
+        collect_statistics=True,
+    )
+    taskmodule.prepare(documents)
+    # we need to set the log level to INFO, otherwise the log messages are not captured
+    with caplog.at_level(logging.INFO):
+        task_encodings = taskmodule.encode(documents)
+    assert len(task_encodings) == 7
+
+    assert len(caplog.messages) == 1
+    expected_message = "statistics:\n"
+    expected_message += "|      |   org:founded_by |   per:employee_of |   per:founder |\n"
+    expected_message += "|:-----|-----------------:|------------------:|--------------:|\n"
+    expected_message += "| used |                2 |                 3 |             2 |"
+    assert caplog.messages[0] == expected_message

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -1444,7 +1444,8 @@ def test_encode_with_collect_statistics(documents, caplog):
 
     assert len(caplog.messages) == 1
     expected_message = "statistics:\n"
-    expected_message += "|      |   org:founded_by |   per:employee_of |   per:founder |\n"
-    expected_message += "|:-----|-----------------:|------------------:|--------------:|\n"
-    expected_message += "| used |                2 |                 3 |             2 |"
+    expected_message += "|           |   org:founded_by |   per:employee_of |   per:founder |\n"
+    expected_message += "|:----------|-----------------:|------------------:|--------------:|\n"
+    expected_message += "| available |                2 |                 3 |             2 |\n"
+    expected_message += "| used      |                2 |                 3 |             2 |"
     assert caplog.messages[0] == expected_message

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -925,7 +925,9 @@ def document_with_nary_relations():
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[NaryRelation] = annotation_field(target="entities")
 
-    document = TestDocumentWithNaryRelations(text="Entity A works at B.")
+    document = TestDocumentWithNaryRelations(
+        text="Entity A works at B.", id="doc_with_nary_relations"
+    )
     document.entities.append(LabeledSpan(start=0, end=8, label="PER"))
     document.entities.append(LabeledSpan(start=18, end=19, label="PER"))
     document.relations.append(
@@ -952,8 +954,8 @@ def test_encode_input_with_add_candidate_relations_with_wrong_relation_type(
         encodings = taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
-        == "the taskmodule does not yet support adding relation candidates for type: "
-        "<class 'pytorch_ie.annotations.NaryRelation'>"
+        == "doc.id=doc_with_nary_relations: the taskmodule does not yet support adding "
+        "relation candidates for type: <class 'pytorch_ie.annotations.NaryRelation'>"
     )
 
 
@@ -998,7 +1000,9 @@ def test_prepare_with_add_reversed_relations_with_label_has_suffix():
         tokenizer_name_or_path=tokenizer_name_or_path,
         add_reversed_relations=True,
     )
-    document = TestDocument(text="Entity A works at B.")
+    document = TestDocument(
+        text="Entity A works at B.", id="doc_with_relation_with_reversed_suffix"
+    )
     document.entities.extend(
         [LabeledSpan(start=0, end=8, label="PER"), LabeledSpan(start=18, end=19, label="PER")]
     )
@@ -1014,9 +1018,9 @@ def test_prepare_with_add_reversed_relations_with_label_has_suffix():
         taskmodule.prepare([document])
     assert (
         str(excinfo.value)
-        == "the relation label 'per:employee_of_reversed' already ends with the reversed_relation_label_suffix "
-        "'_reversed', this is not allowed because we would not know if we should strip the suffix and revert "
-        "the arguments during inference or not"
+        == "doc.id=doc_with_relation_with_reversed_suffix: the relation label 'per:employee_of_reversed' "
+        "already ends with the reversed_relation_label_suffix '_reversed', this is not allowed because "
+        "we would not know if we should strip the suffix and revert the arguments during inference or not"
     )
 
 
@@ -1070,8 +1074,8 @@ def test_encode_input_with_add_reversed_relations_with_wrong_relation_type(
         encodings = taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
-        == "the taskmodule does not yet support adding reversed relations for type:"
-        " <class 'pytorch_ie.annotations.NaryRelation'>"
+        == "doc.id=doc_with_nary_relations: the taskmodule does not yet support adding "
+        "reversed relations for type: <class 'pytorch_ie.annotations.NaryRelation'>"
     )
 
 
@@ -1087,7 +1091,9 @@ def test_span_distance_unknown_type():
 
 
 def test_encode_input_with_max_argument_distance():
-    document = TestDocument(text="Entity A works at B and C.")
+    document = TestDocument(
+        text="Entity A works at B and C.", id="doc_with_three_entities_and_two_relations"
+    )
     e0 = LabeledSpan(start=0, end=8, label="PER")
     e1 = LabeledSpan(start=18, end=19, label="PER")
     e2 = LabeledSpan(start=24, end=25, label="PER")
@@ -1139,8 +1145,8 @@ def test_encode_input_with_max_argument_distance_with_wrong_relation_type(
         encodings = taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
-        == "the taskmodule does not yet support filtering relation candidates for type: "
-        "<class 'pytorch_ie.annotations.NaryRelation'>"
+        == "doc.id=doc_with_nary_relations: the taskmodule does not yet support filtering "
+        "relation candidates for type: <class 'pytorch_ie.annotations.NaryRelation'>"
     )
 
 
@@ -1152,7 +1158,9 @@ def test_encode_input_with_max_argument_distance_with_wrong_argument_type(
         entities: AnnotationList[Label] = annotation_field()
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
-    doc = TestDocumentWithWrongArgumentType(text="Entity A works at B and C.")
+    doc = TestDocumentWithWrongArgumentType(
+        text="Entity A works at B and C.", id="doc_with_wrong_argument_type"
+    )
     doc.entities.extend([Label(label="A"), Label(label="B"), Label(label="C")])
     doc.relations.append(
         BinaryRelation(head=doc.entities[0], tail=doc.entities[1], label="per:employee_of")
@@ -1167,8 +1175,9 @@ def test_encode_input_with_max_argument_distance_with_wrong_argument_type(
         encodings = taskmodule.encode_input(doc)
     assert (
         str(excinfo.value)
-        == "the taskmodule does not yet support filtering relation candidates with arguments of type: "
-        "<class 'pytorch_ie.annotations.Label'> and <class 'pytorch_ie.annotations.Label'>"
+        == "doc.id=doc_with_wrong_argument_type: the taskmodule does not yet support filtering "
+        "relation candidates with arguments of type: <class 'pytorch_ie.annotations.Label'> "
+        "and <class 'pytorch_ie.annotations.Label'>"
     )
 
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -853,7 +853,7 @@ def test_relation_argument_role_unknown(documents):
     )
 
 
-def test_encode_with_create_relation_candidates(documents):
+def test_encode_input_with_add_candidate_relations(documents):
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path,
@@ -861,12 +861,13 @@ def test_encode_with_create_relation_candidates(documents):
     )
     taskmodule.prepare(documents)
     documents_without_relations = []
+    encodings = []
     # just take the first three documents
     for doc in documents[:3]:
         doc_without_relations = doc.copy()
         doc_without_relations.relations.clear()
         documents_without_relations.append(doc_without_relations)
-    encodings = taskmodule.encode(documents_without_relations)
+        encodings.extend(taskmodule.encode(doc_without_relations))
     assert len(encodings) == 4
 
     # There are no entities in the first document, so there are no created relation candidates

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -905,6 +905,39 @@ def test_encode_input_with_add_candidate_relations(documents):
     assert relation.label == "no_relation"
 
 
+def test_encode_input_with_add_reversed_relations(documents):
+    tokenizer_name_or_path = "bert-base-cased"
+    taskmodule = RETextClassificationWithIndicesTaskModule(
+        tokenizer_name_or_path=tokenizer_name_or_path,
+        add_reversed_relations=True,
+    )
+    taskmodule.prepare(documents)
+    encodings = []
+    # just take the first three documents
+    for doc in documents[:3]:
+        encodings.extend(taskmodule.encode_input(doc))
+
+    assert len(encodings) == 2
+
+    # There are no relations in the first and last document, so there are also no new reversed relations
+
+    encoding = encodings[0]
+    assert encoding.document == documents[1]
+    assert encoding.document.text == "Entity A works at B."
+    relation = encoding.metadata["candidate_annotation"]
+    assert str(relation.head) == "Entity A"
+    assert str(relation.tail) == "B"
+    assert relation.label == "per:employee_of"
+
+    encoding = encodings[1]
+    assert encoding.document == documents[1]
+    assert encoding.document.text == "Entity A works at B."
+    relation = encoding.metadata["candidate_annotation"]
+    assert str(relation.head) == "B"
+    assert str(relation.tail) == "Entity A"
+    assert relation.label == "per:employee_of_reversed"
+
+
 def test_encode_with_empty_partition_layer(documents):
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(


### PR DESCRIPTION
This PR integrates most of the functionality of [CandidateRelationAdder](https://github.com/ArneBinder/pie-utils/blob/main/src/pie_utils/document/processors/candidate_relation_adder.py) and [ReversedRelationAdder](https://github.com/ArneBinder/pie-utils/blob/main/src/pie_utils/document/processors/reversed_relation_adder.py) from `pie_utils.document.processors` into the `RETextClassificationWithIndicesTaskModule`.

To do so, it adds:
- `add_candidate_relations` (default: `False`): renamed from `create_relation_candidates`
- `add_reversed_relations` (default: `False`): if enabled, add reversed relations
- `reversed_relation_label_suffix` (default: `"_reversed"`)
- `symmetric_relations` (default: `None`): relations with these labels will get the same label when adding as reversed
- `max_argument_distance` (default: `None`): if defined, exclude relations with argument distance larger than this value 
- `max_argument_distance_type` (default: `"inner"`)

and these methods:
- `_add_reversed_relations()`
- `_add_candidate_relations()`, and 
- `_filter_relations_by_argument_distance()` 

IMPORTANT: This is a breaking change, because
 - `create_relation_candidates` gets renamed to `add_candidate_relations`, and
 - post-processing related to reversed relations during inference (in `create_annotations_from_output()`), i.e. reverting relations back if the label ends with `reversed_relation_label_suffix`, is not triggered by setting that parameter anymore, but only by setting `add_reversed_relations=True`

NOTE: This also adds the parameter `collect_statistics`. If enabled, counts of used / discarded relations are displayed on the console, e.g. when using with `experiment=sciarg_relations` it will show in the following for the `train` split:

|                                    |   contradicts |   contradicts_reversed |   no_relation |   parts_of_same |   semantically_same |   supports |   supports_reversed |
|:-----------------------------------|--------------:|-----------------------:|--------------:|----------------:|--------------------:|-----------:|--------------------:|
| available                          |           519 |                    nan |           nan |             911 |                  31 |       4030 |                 nan |
| skipped_args_not_aligned           |           nan |                    nan |            38 |             nan |                   4 |          4 |                   4 |
| skipped_argument_distance          |            11 |                     11 |        758744 |              52 |                   6 |        160 |                 160 |
| skipped_partially_contained        |           nan |                    nan |           nan |             nan |                   1 |        nan |                 nan |
| skipped_same_arguments             |             1 |                    nan |           nan |             nan |                 nan |          1 |                 nan |
| used                               |           508 |                    508 |         42966 |            1770 |                  50 |       3866 |                3866 |
| used_not_sorted_reversed_arguments |           nan |                    nan |           nan |             621 |                  27 |        nan |                 nan |