### PR TITLE
fix codecov workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,5 +74,8 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          files: ./.coverage,!.venv/**/*
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,12 +70,12 @@ jobs:
       - name: Run tests with coverage
         run: |
           source .venv/bin/activate
-          pytest -k "not slow" --cov --cov-fail-under=90 --cov-report term-missing
+          pytest -k "not slow" --cov --cov-fail-under=90 --cov-report term-missing --cov-report xml:coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./.coverage,!.venv/**/*
+          files: ./coverage.xml
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
explicitly create `coverage.xml` and use that in the codecov upload step

NOTE: The default coverage data file `.coverage` is not supported by codecov, see [here](https://docs.codecov.com/docs/supported-report-formats#non-supported-code-coverage-formats).