### PR TITLE
add codecov config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           source .venv/bin/activate
-          pytest -k "not slow" --cov --cov-fail-under=90 --cov-report term-missing --cov-report xml:coverage.xml
+          pytest -k "not slow" --cov --cov-report term-missing --cov-report xml:coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
... and  do not ensure min test coverage via pytest in CI test workflow because this is already ensured by the codecov bot and breaks creating codecov reports when not hit. This way we get codecov reports even in the middle of the development process and can use this more easily raise the test coverage to the required values.