### PR TITLE
RE inference: do not filter out none-labeled relations if `add_candidate_relation` is disabled

### DIFF
--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -911,7 +911,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                     f"creating a new annotation from a candidate_annotation of another type than BinaryRelation is "
                     f"not yet supported. candidate_annotation has the type: {type(candidate_annotation)}"
                 )
-            if label != self.none_label:
+            if not (self.add_candidate_relations and label == self.none_label):
                 yield self.relation_annotation, new_annotation
 
     def collate(self, task_encodings: Sequence[TaskEncodingType]) -> ModelStepInputType:


### PR DESCRIPTION
if the dataset has annotated none-relations and, thus we do not add them during input encoding, we want to also have them in the predictions