### PR TITLE
improve label handling in RE taskmodule

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1501,6 +1501,20 @@ files = [
 mpmath = ">=0.19"
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "tokenizers"
 version = "0.14.1"
 description = ""
@@ -1925,4 +1939,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "63b7c0b46d85844cf3a2ee528235c4268cc6fb270194dcbd1d364bb3da0fc17d"
+content-hash = "d6865d0f60b78bd5fd9835f13991e4e62a2ffb16b017a921de41152a0a908114"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ torch = {version = "^2.1.0+cpu", source = "pytorch"}
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.4.0"
+tabulate = "^0.9"
 
 [[tool.poetry.source]]
 name = "pytorch"

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -241,7 +241,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         super().__init__(**kwargs)
         if label_to_id is not None:
             logger.warning(
-                "label_to_id is deprecated and will be removed in a future version. "
+                "The parameter label_to_id is deprecated and will be removed in a future version. "
                 "Please use labels instead."
             )
             id_to_label = {v: k for k, v in label_to_id.items()}

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -592,6 +592,11 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             entities_set = set(entities)
             arguments2relation: Dict[Tuple[Tuple[str, Annotation], ...], Annotation] = {}
             for rel in all_relations:
+                # skip relations with unknown labels
+                if rel.label not in self.label_to_id:
+                    self.collect_relation("skipped_unknown_label", rel)
+                    continue
+
                 arguments = get_relation_argument_spans_and_roles(rel)
                 arg_roles, arg_spans = zip(*arguments)
                 # filter out all relations that have arguments not in the current partition

--- a/src/pie_models/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_models/taskmodules/re_text_classification_with_indices.py
@@ -205,7 +205,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             contains relation annotations including negative examples (i.e. relations with the none_label).
     """
 
-    PREPARED_ATTRIBUTES = ["label_to_id", "entity_labels"]
+    PREPARED_ATTRIBUTES = ["labels", "entity_labels"]
 
     def __init__(
         self,
@@ -220,6 +220,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         max_length: Optional[int] = None,
         pad_to_multiple_of: Optional[int] = None,
         multi_label: bool = False,
+        labels: Optional[List[str]] = None,
         label_to_id: Optional[Dict[str, int]] = None,
         add_type_to_marker: bool = False,
         argument_role_to_marker: Optional[Dict[str, str]] = None,
@@ -238,15 +239,24 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.save_hyperparameters()
+        if label_to_id is not None:
+            logger.warning(
+                "label_to_id is deprecated and will be removed in a future version. "
+                "Please use labels instead."
+            )
+            id_to_label = {v: k for k, v in label_to_id.items()}
+            # reconstruct labels from label_to_id. Note that we need to remove the none_label
+            labels = [
+                id_to_label[i] for i in range(len(id_to_label)) if id_to_label[i] != none_label
+            ]
+        self.save_hyperparameters(ignore=["label_to_id"])
 
         self.relation_annotation = relation_annotation
         self.add_candidate_relations = add_candidate_relations
         self.add_reversed_relations = add_reversed_relations
         self.padding = padding
         self.truncation = truncation
-        self.label_to_id = label_to_id or {}
-        self.id_to_label = {v: k for k, v in self.label_to_id.items()}
+        self.labels = labels
         self.max_length = max_length
         self.pad_to_multiple_of = pad_to_multiple_of
         self.multi_label = multi_label
@@ -333,9 +343,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         if self.none_label in relation_labels:
             relation_labels.remove(self.none_label)
 
-        self.label_to_id = {label: i + 1 for i, label in enumerate(sorted(relation_labels))}
-        self.label_to_id[self.none_label] = 0
-
+        self.labels = sorted(relation_labels)
         self.entity_labels = sorted(entity_labels)
 
     def reset_statistics(self):
@@ -412,14 +420,16 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         return sorted(list(argument_markers))
 
     def _post_prepare(self):
+        self.label_to_id = {label: i + 1 for i, label in enumerate(self.labels)}
+        self.label_to_id[self.none_label] = 0
+        self.id_to_label = {v: k for k, v in self.label_to_id.items()}
+
         self.argument_markers = self.construct_argument_markers()
         self.tokenizer.add_tokens(self.argument_markers, special_tokens=True)
 
         self.argument_markers_to_id = {
             marker: self.tokenizer.vocab[marker] for marker in self.argument_markers
         }
-
-        self.id_to_label = {v: k for k, v in self.label_to_id.items()}
 
     def _add_reversed_relations(
         self,

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -34,6 +34,20 @@ def cfg(request):
     return CONFIGS_DICT[request.param]
 
 
+def test_taskmodule_with_deprecated_parameters(caplog):
+    with caplog.at_level(logging.WARNING):
+        tokenizer_name_or_path = "bert-base-cased"
+        taskmodule = RETextClassificationWithIndicesTaskModule(
+            tokenizer_name_or_path=tokenizer_name_or_path, label_to_id={"a": 0, "b": 1}
+        )
+    # check the warning message
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].message
+        == "The parameter label_to_id is deprecated and will be removed in a future version. Please use labels instead."
+    )
+
+
 @pytest.fixture(scope="module")
 def unprepared_taskmodule(cfg):
     tokenizer_name_or_path = "bert-base-cased"

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -40,6 +40,7 @@ def test_taskmodule_with_deprecated_parameters(caplog):
         taskmodule = RETextClassificationWithIndicesTaskModule(
             tokenizer_name_or_path=tokenizer_name_or_path, label_to_id={"a": 0, "b": 1}
         )
+        assert taskmodule.labels == ["a", "b"]
     # check the warning message
     assert len(caplog.records) == 1
     assert (

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import numpy
 import pytest
 import torch
-from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, NaryRelation
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan, NaryRelation
 from pytorch_ie.core import Annotation, AnnotationList, annotation_field
 from pytorch_ie.documents import TextBasedDocument, TextDocument
 
@@ -193,14 +193,9 @@ def test_prepared_taskmodule(taskmodule, documents):
 def test_config(taskmodule):
     config = taskmodule._config()
     assert config["taskmodule_type"] == "RETextClassificationWithIndicesTaskModule"
-    assert "label_to_id" in config
-    assert config["label_to_id"] == {
-        "org:founded_by": 1,
-        "per:employee_of": 2,
-        "per:founder": 3,
-        "no_relation": 0,
-    }
-
+    assert taskmodule.PREPARED_ATTRIBUTES == ["labels", "entity_labels"]
+    assert all(attribute in config for attribute in taskmodule.PREPARED_ATTRIBUTES)
+    assert config["labels"] == ["org:founded_by", "per:employee_of", "per:founder"]
     assert config["entity_labels"] == ["ORG", "PER"]
 
 
@@ -1302,8 +1297,8 @@ def test_encode_nary_relatio():
         relation_annotation="relations",
         tokenizer_name_or_path=tokenizer_name_or_path,
         argument_role_to_marker={"r1": "R1", "r2": "R2", "r3": "R3"},
-        # setting label_to_id and entity_labels makes the taskmodule prepared
-        label_to_id={"rel": 1},
+        # setting labels and entity_labels makes the taskmodule prepared
+        labels=["rel"],
         entity_labels=["a", "b", "c"],
     )
     taskmodule._post_prepare()
@@ -1343,8 +1338,8 @@ def test_encode_unknown_relation_type():
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path=tokenizer_name_or_path,
-        # setting label_to_id and entity_labels makes the taskmodule prepared
-        label_to_id={"has_wrong_type": 1},
+        # setting labels and entity_labels makes the taskmodule prepared
+        labels=["has_wrong_type"],
         entity_labels=["a"],
     )
     taskmodule._post_prepare()
@@ -1376,8 +1371,8 @@ def test_encode_with_unaligned_span(caplog):
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path=tokenizer_name_or_path,
-        # setting label_to_id and entity_labels makes the taskmodule prepared
-        label_to_id={"rel": 1},
+        # setting v and entity_labels makes the taskmodule prepared
+        labels=["rel"],
         entity_labels=["a"],
     )
     taskmodule._post_prepare()


### PR DESCRIPTION
With this PR, it is easier to provide a custom list of labels (instead of using `prepare`). Also, we just skip relations with unknown labels instead of raising an error. 

List of changes:
 - swap `label_to_id` with `labels` in `PREPARED_ATTRIBUTES`
 - `labels` is a list of strings **without the `none_label`**
 - deprecate `label_to_id`, but use it to reconstruct `labels`, if still provided
 - skip relations with unknown label in `encode_input` (but collect them in the statistics)

Note: This also adds `tabulate` to the dev dependencies because we check for correct statistics in the tests.