### PR TITLE
add `SpanLengthCollector` metric

### DIFF
--- a/src/pie_models/metrics/__init__.py
+++ b/src/pie_models/metrics/__init__.py
@@ -1,0 +1,1 @@
+from .span_length_collector import SpanLengthCollector

--- a/src/pie_models/metrics/span_length_collector.py
+++ b/src/pie_models/metrics/span_length_collector.py
@@ -1,0 +1,110 @@
+import logging
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+from pytorch_ie.annotations import Span
+from pytorch_ie.core import Document, DocumentStatistic
+from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.utils.hydra import resolve_optional_document_type
+from transformers import AutoTokenizer, PreTrainedTokenizer
+
+from pie_models.document.processing import tokenize_document
+from pie_models.utils import resolve_type
+
+logger = logging.getLogger(__name__)
+
+
+class SpanLengthCollector(DocumentStatistic):
+    """Collects the lengths of Span annotations. If labels are provided, the lengths collected per
+    label.
+
+    If a tokenizer is provided, the span length is calculated in means of tokens, otherwise in
+    means of characters.
+    """
+
+    DEFAULT_AGGREGATION_FUNCTIONS = ["len", "mean", "std", "min", "max"]
+
+    def __init__(
+        self,
+        layer: str,
+        tokenize: bool = False,
+        tokenizer: Optional[Union[str, PreTrainedTokenizer]] = None,
+        tokenized_document_type: Optional[Union[str, Type[TokenBasedDocument]]] = None,
+        labels: Optional[Union[List[str], str]] = None,
+        label_attribute: str = "label",
+        tokenize_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.layer = layer
+        if isinstance(labels, str) and labels != "INFERRED":
+            raise ValueError("labels must be a list of strings or 'INFERRED'")
+        if labels == "INFERRED":
+            logger.warning(
+                f"Inferring labels with {self.__class__.__name__} from data produces wrong results "
+                f"for certain aggregation functions (e.g. 'mean', 'std', 'min') because zero values "
+                f"are not included in the calculation. We remove these aggregation functions from "
+                f"this collector, but be aware that the results may be wrong for your own aggregation "
+                f"functions that rely on zero values."
+            )
+            self.aggregation_functions: Dict[str, Callable[[List], Any]] = {
+                name: func
+                for name, func in self.aggregation_functions.items()
+                if name not in ["mean", "std", "min"]
+            }
+        self.labels = labels
+        self.label_field = label_attribute
+        self.tokenize = tokenize
+        if self.tokenize:
+            if tokenizer is None:
+                raise ValueError(
+                    "tokenizer must be provided to calculate the span length in means of tokens"
+                )
+            if isinstance(tokenizer, str):
+                tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+            self.tokenizer = tokenizer
+            if tokenized_document_type is None:
+                raise ValueError(
+                    "tokenized_document_type must be provided to calculate the span length in means of tokens"
+                )
+            self.tokenized_document_type = resolve_type(
+                tokenized_document_type, expected_super_type=TokenBasedDocument
+            )
+            self.tokenize_kwargs = tokenize_kwargs or {}
+
+    def _collect(self, doc: Document) -> Union[List[int], Dict[str, List[int]]]:
+        docs: Union[List[Document], List[TokenBasedDocument]]
+        if self.tokenize:
+            if not isinstance(doc, TextBasedDocument):
+                raise ValueError(
+                    "doc must be a TextBasedDocument to calculate the span length in means of tokens"
+                )
+            docs = tokenize_document(
+                doc,
+                tokenizer=self.tokenizer,
+                result_document_type=self.tokenized_document_type,
+                **self.tokenize_kwargs,
+            )
+        else:
+            docs = [doc]
+
+        values: Dict[str, List[int]]
+        if isinstance(self.labels, str):
+            values = defaultdict(list)
+        else:
+            values = {label: [] for label in self.labels or ["ALL"]}
+        for doc in docs:
+            layer_obj = getattr(doc, self.layer)
+            for span in layer_obj:
+                if not isinstance(span, Span):
+                    raise TypeError(
+                        f"span length calculation is not yet supported for {type(span)}"
+                    )
+                length = span.end - span.start
+                if self.labels is None:
+                    label = "ALL"
+                else:
+                    label = getattr(span, self.label_field)
+                values[label].append(length)
+
+        return values if self.labels is not None else values["ALL"]

--- a/tests/metrics/test_span_length_collector.py
+++ b/tests/metrics/test_span_length_collector.py
@@ -1,0 +1,165 @@
+import dataclasses
+
+import pytest
+from pytorch_ie import Document
+from pytorch_ie.annotations import Label, LabeledSpan
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+
+from pie_models.metrics import SpanLengthCollector
+
+
+@pytest.fixture
+def documents():
+    @dataclasses.dataclass
+    class TestDocument(TextBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+    result = []
+    doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
+    doc.entities.append(LabeledSpan(start=16, end=24, label="per"))
+    assert str(doc.entities[0]) == "Entity M"
+    doc.entities.append(LabeledSpan(start=34, end=35, label="org"))
+    assert str(doc.entities[1]) == "N"
+    doc.entities.append(LabeledSpan(start=41, end=43, label="per"))
+    assert str(doc.entities[2]) == "it"
+    doc.entities.append(LabeledSpan(start=52, end=53, label="org"))
+    assert str(doc.entities[3]) == "O"
+
+    result.append(doc)
+
+    # construct another document, but with longer entities
+    doc = TestDocument(
+        text="“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at "
+        "SOSV and managing director of IndieBio."
+    )
+    doc.entities.append(LabeledSpan(start=65, end=75, label="per"))
+    assert str(doc.entities[0]) == "Po Bronson"
+    doc.entities.append(LabeledSpan(start=96, end=100, label="org"))
+    assert str(doc.entities[1]) == "SOSV"
+    doc.entities.append(LabeledSpan(start=126, end=134, label="org"))
+    assert str(doc.entities[2]) == "IndieBio"
+
+    result.append(doc)
+
+    return result
+
+
+def test_documents(documents):
+    pass
+
+
+def test_span_length_collector(documents):
+    statistic = SpanLengthCollector(layer="entities")
+    values = statistic(documents)
+    assert values == {
+        "len": 7,
+        "max": 10,
+        "mean": 4.857142857142857,
+        "min": 1,
+        "std": 3.481730744843983,
+    }
+
+    statistic = SpanLengthCollector(layer="entities", labels="INFERRED")
+    values = statistic(documents)
+    assert values == {"org": {"len": 4, "max": 8}, "per": {"len": 3, "max": 10}}
+
+
+def test_span_length_collector_wrong_label_value():
+    with pytest.raises(ValueError) as excinfo:
+        SpanLengthCollector(layer="entities", labels="WRONG")
+    assert str(excinfo.value) == "labels must be a list of strings or 'INFERRED'"
+
+
+def test_span_length_collector_with_tokenize(documents):
+    @dataclasses.dataclass
+    class TokenizedTestDocument(TokenBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+
+    statistic = SpanLengthCollector(
+        layer="entities",
+        tokenize=True,
+        tokenizer="bert-base-uncased",
+        tokenized_document_type=TokenizedTestDocument,
+    )
+    values = statistic(documents)
+    assert values == {
+        "len": 7,
+        "max": 3,
+        "mean": 1.8571428571428572,
+        "min": 1,
+        "std": 0.8329931278350429,
+    }
+
+
+def test_span_length_collector_with_tokenize_missing_tokenizer():
+    with pytest.raises(ValueError) as excinfo:
+        SpanLengthCollector(
+            layer="entities",
+            tokenize=True,
+            tokenized_document_type=TokenBasedDocument,
+        )
+    assert (
+        str(excinfo.value)
+        == "tokenizer must be provided to calculate the span length in means of tokens"
+    )
+
+
+def test_span_length_collector_with_tokenize_missing_tokenized_document_type():
+    with pytest.raises(ValueError) as excinfo:
+        SpanLengthCollector(
+            layer="entities",
+            tokenize=True,
+            tokenizer="bert-base-uncased",
+        )
+    assert (
+        str(excinfo.value)
+        == "tokenized_document_type must be provided to calculate the span length in means of tokens"
+    )
+
+
+def test_span_length_collector_with_tokenize_wrong_document_type():
+    @dataclasses.dataclass
+    class TestDocument(Document):
+        data: str
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="data")
+
+    doc = TestDocument(data="First sentence. Entity M works at N. And it founded O.")
+    doc.entities.append(LabeledSpan(start=16, end=24, label="per"))
+    assert str(doc.entities[0]) == "Entity M"
+
+    @dataclasses.dataclass
+    class TokenizedTestDocument(TokenBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+
+    statistic = SpanLengthCollector(
+        layer="entities",
+        tokenize=True,
+        tokenizer="bert-base-uncased",
+        tokenized_document_type=TokenizedTestDocument,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        statistic(doc)
+    assert (
+        str(excinfo.value)
+        == "doc must be a TextBasedDocument to calculate the span length in means of tokens"
+    )
+
+
+def test_span_length_collector_with_tokenize_wrong_annotation_type():
+    @dataclasses.dataclass
+    class TestDocument(TextBasedDocument):
+        label: AnnotationList[Label] = annotation_field()
+
+    doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
+    doc.label.append(Label(label="example"))
+
+    statistic = SpanLengthCollector(layer="label")
+
+    with pytest.raises(TypeError) as excinfo:
+        statistic(doc)
+    assert (
+        str(excinfo.value)
+        == "span length calculation is not yet supported for <class 'pytorch_ie.annotations.Label'>"
+    )


### PR DESCRIPTION
This PR adds `metric.SpanLengthCollector`.

This was originally located in [pie-datasets](https://github.com/ArneBinder/pie-datasets), but requires `pie_models.document.processing.tokenize_document`, so we move it to here.